### PR TITLE
Fix websocket URL to connect to current host

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -2,8 +2,8 @@
     // const socket = io({
     //     transports: ['websocket'] // Only use WebSocket transport
     // });
-    const ws = new WebSocket('wss://catchplay.vercel.app');
-    // const ws = new WebSocket('ws://localhost:3000');
+    const wsProtocol = location.protocol === 'https:' ? 'wss' : 'ws';
+    const ws = new WebSocket(`${wsProtocol}://${location.host}`);
 
     const canvas = document.getElementById('gameCanvas');
     const context = canvas.getContext('2d');


### PR DESCRIPTION
## Summary
- use dynamic WebSocket URL based on the page protocol and host

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686025d004dc83329c5cca5aab866383