### PR TITLE
Improve power-ups UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,12 +16,21 @@
             padding: 10px;
             border: 1px solid black;
         }
+        #powerups-ui {
+            position: absolute;
+            top: 10px;
+            left: 10px;
+            background: white;
+            padding: 10px;
+            border: 1px solid black;
+        }
     </style>
     <!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/protobufjs/7.3.2/protobuf.min.js"></script> -->
 </head>
 <body>
     <canvas id="gameCanvas"></canvas>
     <div id="leaderboard"></div>
+    <div id="powerups-ui"></div>
     <!-- <script src="/socket.io/socket.io.js"></script> -->
     <script src="js/game.js"></script>
 </body>

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -127,11 +127,13 @@
                 }
                 catcherId = decodedData.catcherId;
                 powerUps = decodedData.powerUps;
+                updatePowerUpsUI();
                 // player = players[player.id]; // Update the player's own data
                 serverTime = decodedData.timeNow;
                 break;
             case 'updatePowerUps':
                 powerUps = message.data;
+                updatePowerUpsUI();
                 break;
             case 'youAreCatcher':
                 catcherId = player.id;
@@ -140,6 +142,7 @@
                 if (message.data.id === player.id) {
                     burstEffects.push({ x: player.x, y: player.y, startTime: Date.now() });
                 }
+                updatePowerUpsUI();
                 break;
         }
     });
@@ -512,6 +515,28 @@
             playerElement.textContent = `${player.id}: ${player.score.toFixed(2)}`;
             leaderboardElement.appendChild(playerElement);
         });
+    }
+
+    const powerUpColors = {
+        speed: 'green',
+        invisibility: 'purple',
+        shield: 'yellow'
+    };
+
+    function updatePowerUpsUI() {
+        const ui = document.getElementById('powerups-ui');
+        if (!ui) return;
+        const counts = {};
+        for (const p of powerUps) {
+            counts[p.type] = (counts[p.type] || 0) + 1;
+        }
+        ui.innerHTML = '<h3>Power Ups</h3>';
+        for (const type in powerUpColors) {
+            const div = document.createElement('div');
+            div.textContent = `${type}: ${counts[type] || 0}`;
+            div.style.color = powerUpColors[type];
+            ui.appendChild(div);
+        }
     }
 
     // Check if the Catcher has tagged a player


### PR DESCRIPTION
## Summary
- add `<div id="powerups-ui">` element to index.html
- style `#powerups-ui` to show in the top-left
- track power-ups counts client-side and update `powerups-ui`
- call `updatePowerUpsUI` when power-ups data updates

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686033a1dcec8332ad7fd51eeeee320a